### PR TITLE
Upgrade to node16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           npm install
       - run: |
@@ -13,10 +13,10 @@ jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           thresholdNew: 0.8
           thresholdModified: 0.0
-          coverageFile: coverage.xml 
+          coverageFile: coverage.xml

--- a/action.yml
+++ b/action.yml
@@ -2,10 +2,10 @@ name: 'Python Coverage'
 description: 'Publish coverage report to a PR & enforce coverage on new & modified files'
 author: 'orgoro'
 inputs:
-  coverageFile: 
+  coverageFile:
     required: true
     description: 'local path to a covergae xml file like the output of pytest --cov'
-  token: 
+  token:
     required: true
     description: 'github token'
   thresholdAll:
@@ -21,7 +21,7 @@ inputs:
     description: the coverage threshold for average over new files [0,1]
     default: 0.0
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
    icon: 'umbrella'


### PR DESCRIPTION
GitHub have deprecated Node12 and plan to have all actions running on Node16 by summer 2023 (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

This PR sets `action.uses` to `node16`, and also takes the liberty to upgrade the repo's own test workflow to `actions/checkout@v3`, as `@v2` is also slated for deprecation. 🙂 

I'm not sure what release process exists for this action, but I'm happy to help out further to get this released before the deadline.