### PR TITLE
Handle special chars in filenames

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -36,6 +36,10 @@ export function parseCoverageReport(report: string, files: CommitsComparison): F
   return {averageCover: avgCover, newCover, modifiedCover}
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); 
+}
+
 export function parseFilesCoverage(
   report: string,
   source: string,
@@ -43,7 +47,7 @@ export function parseFilesCoverage(
   threshold: number
 ): Coverage[] | undefined {
   const coverages = files?.map(file => {
-    const fileName = file.replace(`${source}/`, '').replace(/\//g, '\\/')
+    const fileName = escapeRegExp(file.replace(`${source}/`, ''))
     const regex = new RegExp(`.*filename="${fileName}".*line-rate="(?<cover>[0-9]+[.]*[0-9]*)".*`)
     const match = report.match(regex)
     const cover = match?.groups ? parseFloat(match.groups['cover']) : -1


### PR DESCRIPTION
Hi, thanks for this awesome action. Noticed this error with my coverage files
```
"Invalid regular expression: /.*filename=\"folder\\/tests\\/__snapshots__\\/test_handlers\\/test_handle[example.com-test0].json\".*line-rate=\"(?<cover>[0-9]+[.]*[0-9]*)\".*/: Range out of order in character class"
```

The error is because of `[example.com-test0]` in filename as `[` and `]` are valid regex syntax.

With this PR filenames with special characters will be correctly handled and escaped with a backslash (\)
