### PR TITLE
Add support for GitHub Merge Queues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ async function run(): Promise<void> {
     core.debug(`coverageFile: ${coverageFile}`)
 
     const eventName = context.eventName
-    if (eventName !== 'pull_request') {
+    if (eventName !== 'pull_request' && eventName !== 'merge_group') {
       core.setFailed(`action support only pull requests but event is ${eventName}`)
       return
     }


### PR DESCRIPTION
When using GitHub [Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) to merge a PR, the event name will be `merge_group` rather than `pull_request`.