### PR TITLE
Update to use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: the coverage threshold for average over new files [0,1]
     default: 0.0
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
    icon: 'umbrella'


### PR DESCRIPTION
Github is deprecating Node 16 as it is now EOL.

This change is just to change the action to use Node 20 in the actions.yml file.
It has been tested in my own workflows and appears to need no other changes.

My suggestion would be to increment the version tag to v4, but that is truly up to the owner of this repo.

