### PR TITLE
Allow an average of 1.0 to pass

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -90,7 +90,7 @@ export function parseAverageCoverage(report: string, threshold: number): Average
       const total = parseFloat(totalMatch.groups['total'])
       const covered = parseFloat(coveredMatch.groups['covered'])
       const ratio = parseFloat(ratioMatch.groups['ratio'])
-      result = {ratio, covered, threshold, total, pass: ratio > threshold}
+      result = {ratio, covered, threshold, total, pass: ratio >= threshold}
     }
   }
   return result ?? setFailed()


### PR DESCRIPTION
I was testing with a repo that had 100% coverage, but a config with `thresholdAll: 1` still did not pass. I went down to .99 to get around it.

But I think this PR solves the root cause.